### PR TITLE
Always use https if available

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
 			<p>Include the following javascript file in your document. </p>
 
 <div class="highlight cf">
-<pre id="stepOne">&lt;script src="//cdn.jsdelivr.net/caniuse-embed/1.1.0/caniuse-embed.min.js"&gt;&lt;/script&gt;</pre>
+<pre id="stepOne">&lt;script src="https://cdn.jsdelivr.net/caniuse-embed/1.1.0/caniuse-embed.min.js"&gt;&lt;/script&gt;</pre>
 <div class="copy-code" id="copyStepOne" data-clipboard-target="#stepOne">Copy</div>
 </div>
 


### PR DESCRIPTION
Thanks for creating this! :)

Just a little change to encourage HTTPS. Per <https://www.paulirish.com/2010/the-protocol-relative-url/>:

> Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the `https://` asset.

<http://cdn.jsdelivr.net/caniuse-embed/1.1.0/caniuse-embed.min.js> seems to be redirecting to HTTPS anyway, but this way people embed this the 'more correct' way.